### PR TITLE
span のときは hover できないようにした

### DIFF
--- a/src/components/ui/Tag/Tag.tsx
+++ b/src/components/ui/Tag/Tag.tsx
@@ -17,19 +17,20 @@ export const Tag: FC<Props> = ({ color, filled = false, onClick, text }) => {
   // inline-styleで対応しているため、stateを使用してhoverを制御。
   const [isHover, setIsHover] = useState(false);
   const Element = onClick ? "button" : "span";
+  const isButton = Element === "button";
 
   // レンダリングの都合上、classNameを動的に設定できないため、inline-styleで対応。
   const style: CSSProperties = filled
     ? {
         color: "white",
         backgroundColor: color,
-        opacity: isHover ? 0.7 : 1.0,
+        opacity: isButton && isHover ? 0.7 : 1.0,
         paddingLeft: 12,
         paddingRight: 12,
       }
     : {
         color,
-        backgroundColor: isHover ? "rgba(0, 0, 0, 0.1)" : "white",
+        backgroundColor: isButton && isHover ? "rgba(0, 0, 0, 0.1)" : "white",
         paddingLeft: 8,
         paddingRight: 8,
       };


### PR DESCRIPTION
- ArticleCard にタグを表示するときは、スクロール領域内なので、スクロールというアクションとボタンである挙動がコンフリクトして UX が損なわれるのを考慮し、 hover できないようにした